### PR TITLE
Proper memory management

### DIFF
--- a/N_algorithm.hpp
+++ b/N_algorithm.hpp
@@ -63,9 +63,11 @@ private:
 	}
 
 public:
-	static std::array<dfs_iterator::generator_t, 3> generate_fns_for_tree(const r2vec_t& r)
+	static dfs_iterator::generator_fns_container_t generate_fns_for_tree(const r2vec_t& r)
 	{
-		return { std::bind_front(g0, r), std::bind_front(g1, r), std::bind_front(gm1, r) };
+		return { std::bind_front(g0, r),
+			std::bind_front(g1, r), 
+			std::bind_front(gm1, r) };
 	}
 
 	static bool stop_iterating_value(const r2vec_t& r, const r2vec_t& t)

--- a/N_algorithm.hpp
+++ b/N_algorithm.hpp
@@ -28,7 +28,7 @@ class N_algorithm_functor : public dfs_bandt_algorithm_functor<N_algorithm_funct
 	
 public:
 
-	N_algorithm_functor(memory_layout_t& memory): base_t(memory) {}
+	N_algorithm_functor(std::pmr::memory_resource* rsc) noexcept: base_t(rsc) {}
 
 	static bool is_trivially_inside(r2vec_t r)
 	{

--- a/algorithm_concepts.hpp
+++ b/algorithm_concepts.hpp
@@ -27,6 +27,10 @@ namespace frc
         {F::is_trivially_outside(r)} -> std::convertible_to<bool>;
     };
 
+
+    template<typename T, std::size_t N>
+    class recursive_tree_dfs_iterator;
+
     /* A concept to represent the algorithm described in Bandt's paper for
     * determining connctedness loci of a linear IFS
     * 
@@ -42,9 +46,12 @@ namespace frc
     template<typename F, typename ValueT, std::size_t N>
     concept bandt_like_fractal_algorithm = fractal_algorithm<F, ValueT> &&
         requires(const ValueT & r, const ValueT & t) {
+        typename F::dfs_iterator;
+            requires std::same_as<typename F::dfs_iterator, 
+                recursive_tree_dfs_iterator<ValueT, N>>;
 
             {F::generate_fns_for_tree(r)}->
-                std::convertible_to < std::array<typename F::dfs_iterator::generator_t, N>>;
+                std::convertible_to < typename F::dfs_iterator::generator_fns_container_t>;
             {F::stop_iterating_value(r, t)} ->
                 std::convertible_to<bool>;
             {F::root(r)} -> std::convertible_to<ValueT>;

--- a/algorithm_concepts.hpp
+++ b/algorithm_concepts.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <concepts>
 #include <array>
+#include <memory>
+
 namespace frc
 {
     /* A concept that represents an algorithm to decide if a point is inside a fractal.
@@ -14,8 +16,7 @@ namespace frc
     template<typename F, typename ValueT>
     concept fractal_algorithm = std::regular_invocable<F, ValueT&, unsigned int> &&
         requires {
-        typename F::memory_layout_t;
-            requires std::constructible_from<F, typename F::memory_layout_t&>;
+                requires std::constructible_from<F, std::pmr::memory_resource*>;
             requires std::is_convertible_v<
                 std::invoke_result_t<F, ValueT&, unsigned int>,
                     unsigned int>;

--- a/bandt_algorithm.hpp
+++ b/bandt_algorithm.hpp
@@ -49,9 +49,11 @@ private:
 
 public:
 
-	static std::array<dfs_iterator::generator_t, 3> generate_fns_for_tree(const std::complex<double>& r)
+	static dfs_iterator::generator_fns_container_t generate_fns_for_tree(const std::complex<double>& r)
 	{
-		return { std::bind_front(g0, r), std::bind_front(g1, r), std::bind_front(gm1, r) };
+		return { std::bind_front(g0, r),
+			std::bind_front(g1, r),
+			std::bind_front(gm1, r) };
 	}
 
 	static bool stop_iterating_value(const std::complex<double>& r, const std::complex<double>& t)

--- a/bandt_algorithm.hpp
+++ b/bandt_algorithm.hpp
@@ -6,6 +6,7 @@
 #include "utils.hpp"
 #include "recursive_tree_dfs_iterator.hpp"
 #include "dfs_bandt_algorithm.hpp"
+
 namespace frc
 {
 class bandt_algorithm_functor : 
@@ -14,7 +15,7 @@ class bandt_algorithm_functor :
 	using base_t = dfs_bandt_algorithm_functor<bandt_algorithm_functor, std::complex<double>, 3>;
 public:
 
-	bandt_algorithm_functor(memory_layout_t& memory) noexcept : base_t(memory) {}
+	bandt_algorithm_functor(std::pmr::memory_resource* rsc) noexcept : base_t(rsc) {}
 
 	static bool is_trivially_inside(std::complex<double> r)
 	{

--- a/dfs_bandt_algorithm.hpp
+++ b/dfs_bandt_algorithm.hpp
@@ -8,11 +8,11 @@ namespace frc
 template<typename Derived, typename T, std::size_t N>
 class dfs_bandt_algorithm_functor
 {
-	using dfs_iterator = recursive_tree_dfs_iterator<T, N>;
 protected:
     std::pmr::memory_resource* memory;
 
 public:
+	using dfs_iterator = recursive_tree_dfs_iterator<T, N>;
 
 	dfs_bandt_algorithm_functor(std::pmr::memory_resource* memory) noexcept: memory(memory)
     {

--- a/dfs_bandt_algorithm.hpp
+++ b/dfs_bandt_algorithm.hpp
@@ -9,15 +9,19 @@ template<typename Derived, typename T, std::size_t N>
 class dfs_bandt_algorithm_functor
 {
 	using dfs_iterator = recursive_tree_dfs_iterator<T, N>;
+protected:
+    std::pmr::memory_resource* memory;
 
 public:
-	struct memory_layout_t
-	{
-	};
 
-	dfs_bandt_algorithm_functor(memory_layout_t& memory) noexcept
+	dfs_bandt_algorithm_functor(std::pmr::memory_resource* memory) noexcept: memory(memory)
     {
         static_assert(bandt_like_fractal_algorithm<Derived, T, N>);
+    }
+
+    static constexpr std::size_t approximate_maximal_dynamic_memory(unsigned int max_iterations)
+    {
+        return (sizeof(T) + sizeof(std::size_t)) * max_iterations + sizeof(T);
     }
 
     /* This algorithm is a DFS approach to the algorithm described in
@@ -42,7 +46,8 @@ public:
 
         dfs_iterator tree_iterator(Derived::generate_fns_for_tree(r),
             Derived::root(r),
-            max_iterations);
+            max_iterations,
+            memory);
 
         const auto stop_condition = [&r](const T& t) -> bool
         {

--- a/main.cpp
+++ b/main.cpp
@@ -14,9 +14,14 @@ int main()
     //draw_M(std::format("pics/bandt_{}_depth_{}.bmp", m_pic_name, 20),
     //    m_res, m_dom, 20);
 
-    //draw_M("pics/M_debug.bmp",
-    //    resolution_t{ 600, 600 },
-    //    picture_domain_t{ .x{0, 1.0/std::sqrt(2)}, .y{0, 1.0 / std::sqrt(2)} }, 30);
+    draw_mandlebrot("pics/mandlebrot_debug.bmp",
+        resolution_t{ 600, 600 },
+        picture_domain_t{ .x{-1, 1}, .y{-1, 1 } },
+        100);
+
+    draw_M("pics/M_debug.bmp",
+        resolution_t{ 600, 600 },
+        picture_domain_t{ .x{0, 1.0/std::sqrt(2)}, .y{0, 1.0 / std::sqrt(2)} }, 30);
 
     draw_N("pics/N_debug.bmp",
         resolution_t{ 600, 600 },

--- a/mandlebrot_algorithm.hpp
+++ b/mandlebrot_algorithm.hpp
@@ -13,8 +13,7 @@ unsigned int iterate_mandlebrot(std::complex<double>& c, unsigned int max_iterat
 
 struct mandlebrot_algorithm_functor
 {
-    struct memory_layout_t {};
-    mandlebrot_algorithm_functor(memory_layout_t&) noexcept {};
+    mandlebrot_algorithm_functor(std::pmr::memory_resource* rsc = nullptr) noexcept {};
     unsigned int operator()(std::complex<double>& c, unsigned int max_iterations) const
     {
         return iterate_mandlebrot(c, max_iterations);

--- a/recursive_tree_dfs_iterator.hpp
+++ b/recursive_tree_dfs_iterator.hpp
@@ -19,12 +19,12 @@ template<typename T,
 class recursive_tree_dfs_iterator
 {
 	const unsigned max_depth;
-	std::vector<T> previous_values;
-	std::vector<int> previous_ids;
+	std::pmr::vector<T> previous_values;
+	std::pmr::vector<int> previous_ids;
 	using value_generators_t = std::array<std::function<T(const T&)>, N>;
 	const value_generators_t new_value_generators;
 
-	recursive_tree_dfs_iterator(value_generators_t gens) : max_depth(0), 
+	recursive_tree_dfs_iterator(value_generators_t gens) noexcept: max_depth(0), 
 		new_value_generators(gens) {}
 
 	void traverse_up_until_not_last_child()
@@ -56,10 +56,11 @@ public:
 
 	recursive_tree_dfs_iterator(value_generators_t gens,
 		const T& start_value,
-		unsigned int max_depth) :
+		unsigned int max_depth,
+		std::pmr::memory_resource* rsc) :
 		max_depth(max_depth), 
-		previous_values{}, 
-		previous_ids{},
+		previous_values{rsc}, 
+		previous_ids{rsc},
 		new_value_generators(gens)
 	{
 		previous_values.reserve(max_depth + 1);
@@ -68,7 +69,8 @@ public:
 		this->reset(start_value, max_depth);
 	}
 	recursive_tree_dfs_iterator(value_generators_t gens, 
-		unsigned int max_depth) : recursive_tree_dfs_iterator(gens, {}, {}, max_depth) {}
+		unsigned int max_depth,
+		std::pmr::memory_resource* rsc) : recursive_tree_dfs_iterator(gens, {}, {}, max_depth, rsc) {}
 
 	recursive_tree_dfs_iterator(const recursive_tree_dfs_iterator&) = default;
 	recursive_tree_dfs_iterator(recursive_tree_dfs_iterator&&) = default;

--- a/run_algorithm_per_pixel.hpp
+++ b/run_algorithm_per_pixel.hpp
@@ -1,6 +1,7 @@
 #pragma once
-#include "utils.hpp"
+#include <memory_resource>
 
+#include "utils.hpp"
 namespace frc
 {
 
@@ -24,9 +25,10 @@ run_algorithm_per_pixel(
 	unsigned int max_iterations)
 {
     // Initialize memory required to run the algorithm
-    typename IsInFractal::memory_layout_t alg_memory{};
+    const auto dynamic_size = caclulate_pre_allocation_buffer_size<IsInFractal>(max_iterations);
+    std::pmr::monotonic_buffer_resource pool{ dynamic_size };
 
-    IsInFractal algorithm(alg_memory);
+    IsInFractal algorithm(&pool);
 
     for (auto x = 0u; x < res.width; x++)
     {
@@ -65,9 +67,10 @@ std::generator<std::tuple<pixel_coordinates_t,
         unsigned int max_iterations)
 {
     // Initialize memory required to run the algorithm
-    typename IsInFractal::memory_layout_t alg_memory{};
+    const auto dynamic_size = caclulate_pre_allocation_buffer_size<IsInFractal>(max_iterations);
+    std::pmr::monotonic_buffer_resource pool{ dynamic_size };
 
-    IsInFractal algorithm(alg_memory);
+    IsInFractal algorithm(&pool);
 
     for (auto x = 0u; x < res.width; x++)
     {

--- a/utils.hpp
+++ b/utils.hpp
@@ -171,4 +171,22 @@ concept complex_fractal_algorithm = fractal_algorithm < F, std::complex<double>>
 template<typename F>
 concept r2_fractal_algorithm = fractal_algorithm < F, r2vec_t>;
 
+/* A type that declares how much memory it requires will use it,
+*  otherwise don't pre-allocate anything
+*/
+template<typename Alg>
+constexpr std::size_t caclulate_pre_allocation_buffer_size(unsigned int max_iterations)
+{
+    if constexpr (
+        requires {
+            {Alg::approximate_maximal_dynamic_memory(max_iterations) } ->
+                std::convertible_to<std::size_t>; })
+    {
+        return Alg::approximate_maximal_dynamic_memory(max_iterations);
+    }
+    else
+    {
+        return 0;
+    }
+}
 }


### PR DESCRIPTION
Refactor the memory management in two ways:
1. Use `std::pmr` - closes #13 

2. Use (if avilable) `std::move_only_function` to guarantee no allocations when constructing the DFS iterator.

Note that if `std::bind_front(g0, r)` fits in `std::function`'s SBO then the second change is meaningless.